### PR TITLE
Update setup-edison.md

### DIFF
--- a/docs/docs/walkthrough/phase-0/setup-edison.md
+++ b/docs/docs/walkthrough/phase-0/setup-edison.md
@@ -230,14 +230,22 @@ Out:   serial
 Err:   serial
 Hit any key to stop autoboot:  0 
 ```
-1. Hit any key to drop to a prompt and type:  
+1. Hit any key to drop to a prompt and type: 
+
 `printenv bootargs_target`
+
 2. If the answer is  
-`bootargs_target=first-install`  
+
+`bootargs_target=first-install` 
+
 then type:  
-`setenv bootargs_target multi-user`   
+
+`setenv bootargs_target multi-user`  
+
 `saveenv`  
+
 3. And to exit that firmware u-boot prompt:  
+
 `run do_boot`
 
 ### Override DNS resolvers


### PR DESCRIPTION
Added newlines because on http://openaps.readthedocs.io/en/master/docs/walkthrough/phase-0/setup-edison.html this information is not displayed correctly.  Some newlines are missing and the resulting display appears as follows 

Hit any key to drop to a prompt and type:printenv bootargs_target
If the answer isbootargs_target=first-installthen type:setenv bootargs_target multi-usersaveenv
And to exit that firmware u-boot prompt:run do_boot

Making the arguments to setenv appear to be bootargs_target multi-usersaveenv and not show the call to saveenv at all